### PR TITLE
(fix) deployment, use pip-installed ansible to fix python_terraform dependency not picked up

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -71,7 +71,13 @@ jobs:
         run: sudo add-apt-repository universe
 
       - name: Setting up dependencies tooling
-        run: sudo apt-get install python3 python3-pip python3-setuptools python3-wheel ansible
+        run: sudo apt-get install python3 python3-pip python3-setuptools python3-wheel
+
+      - name: Install ansible
+        run: pip install ansible
+
+      - name: Ansible debug info
+        run: ansible --version && pip --version && python --version
 
       - name: Fix Ansible bug (https://github.com/ansible/ansible/issues/27793)
         run: rm -rf ~/.ansible/cp


### PR DESCRIPTION
https://github.com/arigativa/robolive/runs/2313029473?check_suite_focus=true#step:18:8