### PR TITLE
volume for robot configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 target/
 .idea/
 classes/
+robot_configs/
 
 # dependencies
 **/node_modules

--- a/README.md
+++ b/README.md
@@ -115,10 +115,11 @@ export VIDEO_SRC='nvarguscamerasrc sensor_mode=3 ! video/x-raw(memory:NVMM),widt
 
 
 ### Run robot connected to Production using docker
-
+First you need to create `robot_configs` directory in project root.  
+Then run docker-compose command below:  
 ```shell script
-CONFIG_PATH is where robot credentials will be stored
-docker-compose run --no-deps -e REGISTRY_HOST=rl.arigativa.ru -e INVENTORY_USE_PLAINTEXT=false -e ROBOT_NAME='FromDevMachine' -e CONFIG_PATH=./robot.cfg robot
+# CONFIG_PATH is where robot credentials will be stored
+docker-compose run --no-deps -e REGISTRY_HOST=rl.arigativa.ru -e INVENTORY_USE_PLAINTEXT=false -e ROBOT_NAME='FromDevMachine' robot
 ```
 
 #### sensor_mode values

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,12 @@ services:
       REGISTRY_PORT_FOR_AGENT: 10476
       REGISTRY_PORT_FOR_STORAGE: 10479
       REGISTRY_PORT_FOR_SIP_CHANNEL: 10480
-      CONFIG_PATH: ./robot.cfg
+      CONFIG_PATH: /app/robot_configs/robot.cfg
+    volumes:
+      - type: bind
+        source: ./robot_configs
+        target: /app/robot_configs
+        read_only: false
     depends_on:
       - registry
       - envoy


### PR DESCRIPTION
volume для робота, теперь можно создать в корне проекта папку:  robot_configs и он туда будет класть логин и пароль, либо можно создать и положить свои (robot.cfg) и он их подтянет, и при запуске робота docker-compose не нужно больше указывать CONFIG переменную окружения, она уже вписана как надо в docker-compose файл